### PR TITLE
docs: update readme source files

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -72,13 +72,8 @@ custom_content: |
   }
   ```
 about: |
-  [Google Cloud Pub/Sub Lite][product-docs] is a zonal, real-time messaging
-  service that lets you send and receive messages between independent
-  applications. You can manually configure the throughput and storage capacity
-  for Pub/Sub Lite systems.
-
-  Because Pub/Sub Lite provides partitioned zonal data storage with
-  predefined capacity, a large portion of the Kafka Producer/Consumer API can
+  Because [Google Cloud Pub/Sub Lite][product-docs] provides partitioned zonal data storage with
+  predefined capacity. A large portion of the Kafka Producer/Consumer API can
   be implemented using Pub/Sub Lite as a backend. The key differences are:
   - Pub/Sub Lite does not support transactions. All transaction methods on
     `Producer<byte[], byte[]>` will raise an exception.

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -72,20 +72,14 @@ custom_content: |
   }
   ```
 about: |
-  [Google Pub/Sub Lite][product-docs] is designed to provide reliable,
-  many-to-many, asynchronous messaging between applications. Publisher
-  applications can send messages to a topic and other applications can
-  subscribe to that topic to receive the messages. By decoupling senders and
-  receivers, Google Cloud Pub/Sub allows developers to communicate between
-  independently written applications. See the
-  [Google Pub/Sub Lite docs](https://cloud.google.com/pubsub/quickstart-console#before-you-begin)
-  for more details on how to activate Pub/Sub Lite for your project, as well as
-  guidance on how to choose between Cloud Pub/Sub and Pub/Sub Lite.
+  [Google Cloud Pub/Sub Lite][product-docs] is a zonal, real-time messaging
+  service that lets you send and receive messages between independent
+  applications. You can manually configure the throughput and storage capacity
+  for Pub/Sub Lite systems.
 
-  Compared to Google Pub/Sub, Pub/Sub Lite provides partitioned zonal data
-  storage with predefined capacity. This means a large portion of the Kafka
-  Producer/Consumer API can be implemented using Pub/Sub Lite as a backend. The
-  key differences are:
+  Because Pub/Sub Lite provides partitioned zonal data storage with
+  predefined capacity, a large portion of the Kafka Producer/Consumer API can
+  be implemented using Pub/Sub Lite as a backend. The key differences are:
   - Pub/Sub Lite does not support transactions. All transaction methods on
     `Producer<byte[], byte[]>` will raise an exception.
   - Producers operate on a single topic, and Consumers on a single subscription.

--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -73,7 +73,7 @@ custom_content: |
   ```
 about: |
   Because [Google Cloud Pub/Sub Lite][product-docs] provides partitioned zonal data storage with
-  predefined capacity. A large portion of the Kafka Producer/Consumer API can
+  predefined capacity, a large portion of the Kafka Producer/Consumer API can
   be implemented using Pub/Sub Lite as a backend. The key differences are:
   - Pub/Sub Lite does not support transactions. All transaction methods on
     `Producer<byte[], byte[]>` will raise an exception.

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
   "name": "pubsublite-kafka",
   "name_pretty": "Pub/Sub Lite Kafka Shim",
   "product_documentation": "https://cloud.google.com/pubsub/lite/docs",
-  "api_description": "is designed to provide reliable,\nmany-to-many, asynchronous messaging between applications. Publisher\napplications can send messages to a topic and other applications can\nsubscribe to that topic to receive the messages. By decoupling senders and\nreceivers, Google Cloud Pub/Sub allows developers to communicate between\nindependently written applications.\n\nCompared to Google Pub/Sub, Pub/Sub Lite provides partitioned zonal data\nstorage with predefined capacity. Both products present a similar API, but\nPub/Sub Lite has more usage caveats.\n\nSee the [Google Pub/Sub Lite docs](https://cloud.google.com/pubsub/quickstart-console#before-you-begin) for more details on how to activate\nPub/Sub Lite for your project, as well as guidance on how to choose between\nCloud Pub/Sub and Pub/Sub Lite.",
+  "api_description": "Pub/Sub Lite is a zonal, real-time messaging service that lets you send and receive messages between independent applications. You can manually configure the throughput and storage capacity for Pub/Sub Lite systems.",
   "client_documentation": "https://googleapis.dev/java/google-cloud-pubsublite/latest/index.html",
   "release_level": "beta",
   "transport": "grpc",

--- a/samples/snippets/pom.xml
+++ b/samples/snippets/pom.xml
@@ -40,6 +40,8 @@
 
   <dependencies>
     <!-- TODO: switch to libraries-bom after this artifact is included -->
+    <!-- [START pubsublite-kafka_install_without_bom] -->
+    <!-- [START pubsublite-kafka_java_dependencies] -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>pubsublite-kafka</artifactId>
@@ -50,6 +52,8 @@
       <artifactId>kafka-clients</artifactId>
       <version>2.7.0</version>
     </dependency>
+    <!-- [END pubsublite-kafka_java_dependencies] -->
+    <!-- [END pubsublite-kafka_install_without_bom] -->
 
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Fixes #50 

The region tags should cause autosynth to regenerate the quickstart section of the readme:
- https://github.com/googleapis/synthtool/tree/master/synthtool/gcp/templates/java_library
- https://github.com/googleapis/synthtool/blob/master/synthtool/languages/java.py