### PR TITLE
feat: Implement Consumer.offsetsForTimes

### DIFF
--- a/src/main/java/com/google/cloud/pubsublite/kafka/PubsubLiteConsumer.java
+++ b/src/main/java/com/google/cloud/pubsublite/kafka/PubsubLiteConsumer.java
@@ -34,9 +34,11 @@ import com.google.cloud.pubsublite.internal.wire.PartitionAssignmentReceiver;
 import com.google.cloud.pubsublite.proto.Cursor;
 import com.google.cloud.pubsublite.proto.SeekRequest;
 import com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
+import com.google.protobuf.util.Timestamps;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
@@ -59,7 +61,6 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
 
 /**
  * A class that uses a SingleSubscriptionConsumer to remove the duplicate methods from the kafka
@@ -466,8 +467,33 @@ class PubsubLiteConsumer implements Consumer<byte[], byte[]> {
   @Override
   public Map<TopicPartition, OffsetAndTimestamp> offsetsForTimes(
       Map<TopicPartition, Long> map, Duration duration) {
-    throw new UnsupportedVersionException(
-        "Pub/Sub Lite does not support Consumer backlog introspection.");
+    try {
+      Map<TopicPartition, ApiFuture<Optional<Cursor>>> cursors =
+          map.entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      entry -> entry.getKey(),
+                      entry ->
+                          topicStatsClient.computeCursorForEventTime(
+                              topicPath,
+                              checkTopicGetPartition(entry.getKey()),
+                              Timestamps.fromMillis(entry.getValue()))));
+      ApiFutures.allAsList(cursors.values()).get(duration.toMillis(), TimeUnit.MILLISECONDS);
+
+      // As per KafkaConsumer.offsetsForTimes, null (represented by no map entry) is returned if
+      // there is no result for the partition.
+      ImmutableMap.Builder<TopicPartition, OffsetAndTimestamp> output = ImmutableMap.builder();
+      for (Map.Entry<TopicPartition, ApiFuture<Optional<Cursor>>> entry : cursors.entrySet()) {
+        Optional<Cursor> cursor = entry.getValue().get();
+        if (cursor.isPresent()) {
+          Long timestamp = Preconditions.checkNotNull(map.get(entry.getKey()));
+          output.put(entry.getKey(), new OffsetAndTimestamp(cursor.get().getOffset(), timestamp));
+        }
+      }
+      return output.build();
+    } catch (Throwable t) {
+      throw toKafka(t);
+    }
   }
 
   @Override

--- a/src/test/java/com/google/cloud/pubsublite/kafka/PubsubLiteConsumerTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/kafka/PubsubLiteConsumerTest.java
@@ -55,6 +55,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.reflect.ImmutableTypeToInstanceMap;
 import com.google.protobuf.util.Timestamps;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -491,7 +492,11 @@ public class PubsubLiteConsumerTest {
         .thenReturn(ApiFutures.immediateFuture(Optional.empty()));
     Map<TopicPartition, OffsetAndTimestamp> output =
         consumer.offsetsForTimes(ImmutableMap.of(partition2, 2000L, partition4, 4000L));
-    assertThat(output).isEqualTo(ImmutableMap.of(partition2, new OffsetAndTimestamp(22, 2000)));
+
+    Map<TopicPartition, OffsetAndTimestamp> expected = new HashMap<>();
+    expected.put(partition2, new OffsetAndTimestamp(22, 2000));
+    expected.put(partition4, null);
+    assertThat(output).isEqualTo(expected);
   }
 
   @Test


### PR DESCRIPTION
Retrieves cursors for timestamps from the `TopicStatsClient` to implement `PubsubLiteConsumer.offsetsForTimes`.
