### PR TITLE
docs: update readme partials

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -80,5 +80,3 @@ about: |
   - Producers operate on a single topic, and Consumers on a single subscription.
   - ProducerRecord may not specify partition explicitly.
   - Consumers may not dynamically create consumer groups (subscriptions).
-  - `Consumer.offsetsForTimes` and `Consumer.endOffsets` will raise an
-    exception.


### PR DESCRIPTION
Removes comment about `Consumer.offsetsForTimes` and `Consumer.endOffsets`, as these are now implemented.

Attempt 2 - removing from the source readme-partials.yaml file.