### PR TITLE
deps: update google-cloud-pubsublite to v0.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,12 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-cloud-pubsublite-v1</artifactId>
-      <version>0.14.2</version>
+      <version>0.15.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-pubsublite</artifactId>
-      <version>0.14.2</version>
+      <version>0.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>

--- a/src/main/java/com/google/cloud/pubsublite/kafka/ConsumerSettings.java
+++ b/src/main/java/com/google/cloud/pubsublite/kafka/ConsumerSettings.java
@@ -118,13 +118,14 @@ public abstract class ConsumerSettings {
                                         PubsubContext.of(FRAMEWORK),
                                         RoutingMetadata.of(subscriptionPath(), partition),
                                         SubscriberServiceSettings.newBuilder()))))
+                        .setInitialLocation(initialSeek)
                         .build();
                   } catch (Throwable t) {
                     throw toCanonical(t).underlying;
                   }
                 };
             return new BufferingPullSubscriber(
-                subscriberFactory, perPartitionFlowControlSettings(), initialSeek);
+                subscriberFactory, perPartitionFlowControlSettings());
           };
       CommitterFactory committerFactory =
           partition -> {


### PR DESCRIPTION
Manual update to handle the interface change of `BufferingPullSubscriber` - the `SubscriberBuilder` now accepts an initial location when connecting a new Subscribe stream.