### PR TITLE
feat: Reset Consumer upon out-of-band seek

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -80,3 +80,9 @@ about: |
   - Producers operate on a single topic, and Consumers on a single subscription.
   - ProducerRecord may not specify partition explicitly.
   - Consumers may not dynamically create consumer groups (subscriptions).
+
+  Note:
+  - In order to use Pub/Sub Lite [seek operations](https://cloud.google.com/pubsub/lite/docs/seek),
+    Consumers must have auto-commit enabled. Consumer seek methods are client-initiated, whereas
+    Pub/Sub Lite seek operations are initiated out-of-band and pushed to Consumers. Both types of
+    seeks should not be used concurrently, as they would interfere with one another.

--- a/src/main/java/com/google/cloud/pubsublite/kafka/ConsumerSettings.java
+++ b/src/main/java/com/google/cloud/pubsublite/kafka/ConsumerSettings.java
@@ -101,7 +101,7 @@ public abstract class ConsumerSettings {
             }
           };
       PullSubscriberFactory pullSubscriberFactory =
-          (partition, initialSeek) -> {
+          (partition, initialSeek, resetHandler) -> {
             SubscriberFactory subscriberFactory =
                 consumer -> {
                   try {
@@ -118,6 +118,7 @@ public abstract class ConsumerSettings {
                                         RoutingMetadata.of(subscriptionPath(), partition),
                                         SubscriberServiceSettings.newBuilder()))))
                         .setInitialLocation(initialSeek)
+                        .setResetHandler(resetHandler)
                         .build();
                   } catch (Throwable t) {
                     throw toCanonical(t).underlying;

--- a/src/main/java/com/google/cloud/pubsublite/kafka/PullSubscriberFactory.java
+++ b/src/main/java/com/google/cloud/pubsublite/kafka/PullSubscriberFactory.java
@@ -19,10 +19,12 @@ package com.google.cloud.pubsublite.kafka;
 import com.google.cloud.pubsublite.Partition;
 import com.google.cloud.pubsublite.internal.BlockingPullSubscriber;
 import com.google.cloud.pubsublite.internal.CheckedApiException;
+import com.google.cloud.pubsublite.internal.wire.SubscriberResetHandler;
 import com.google.cloud.pubsublite.proto.SeekRequest;
 
 /** A factory for making new PullSubscribers for a given partition of a subscription. */
 interface PullSubscriberFactory {
-  BlockingPullSubscriber newPullSubscriber(Partition partition, SeekRequest initial)
+  BlockingPullSubscriber newPullSubscriber(
+      Partition partition, SeekRequest initial, SubscriberResetHandler resetHandler)
       throws CheckedApiException;
 }

--- a/src/main/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriber.java
+++ b/src/main/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriber.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.kafka;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.Partition;
+import com.google.cloud.pubsublite.SequencedMessage;
+import com.google.cloud.pubsublite.internal.BlockingPullSubscriber;
+import com.google.cloud.pubsublite.internal.CheckedApiException;
+import com.google.cloud.pubsublite.internal.CloseableMonitor;
+import com.google.cloud.pubsublite.internal.wire.Committer;
+import com.google.cloud.pubsublite.proto.SeekRequest;
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import java.util.ArrayDeque;
+import java.util.Optional;
+
+/** Pulls messages and manages commits for a single partition of a subscription. */
+class SinglePartitionSubscriber {
+  private final PullSubscriberFactory subscriberFactory;
+  private final Partition partition;
+  private final Committer committer;
+
+  private final CloseableMonitor monitor = new CloseableMonitor();
+
+  @GuardedBy("monitor.monitor")
+  private BlockingPullSubscriber subscriber;
+
+  @GuardedBy("monitor.monitor")
+  private boolean needsCommitting = false;
+
+  @GuardedBy("monitor.monitor")
+  private Optional<Offset> lastReceived = Optional.empty();
+
+  SinglePartitionSubscriber(
+      PullSubscriberFactory subscriberFactory,
+      Partition partition,
+      SeekRequest initialSeek,
+      Committer committer)
+      throws CheckedApiException {
+    this.subscriberFactory = subscriberFactory;
+    this.partition = partition;
+    this.committer = committer;
+    this.subscriber =
+        subscriberFactory.newPullSubscriber(partition, initialSeek, this::onSubscriberReset);
+  }
+
+  /** Executes a client-initiated seek. */
+  void clientSeek(SeekRequest request) throws CheckedApiException {
+    try (CloseableMonitor.Hold h = monitor.enter()) {
+      subscriber.close();
+      subscriber = subscriberFactory.newPullSubscriber(partition, request, this::onSubscriberReset);
+    }
+  }
+
+  ApiFuture<Void> onData() {
+    try (CloseableMonitor.Hold h = monitor.enter()) {
+      return subscriber.onData();
+    }
+  }
+
+  @GuardedBy("monitor.monitor")
+  private ArrayDeque<SequencedMessage> pullMessages() throws CheckedApiException {
+    ArrayDeque<SequencedMessage> messages = new ArrayDeque<>();
+    for (Optional<SequencedMessage> message = subscriber.messageIfAvailable();
+        message.isPresent();
+        message = subscriber.messageIfAvailable()) {
+      messages.add(message.get());
+    }
+    return messages;
+  }
+
+  /** Pulls all available messages. */
+  ArrayDeque<SequencedMessage> getMessages() throws CheckedApiException {
+    try (CloseableMonitor.Hold h = monitor.enter()) {
+      ArrayDeque<SequencedMessage> messages = pullMessages();
+      if (!messages.isEmpty()) {
+        lastReceived = Optional.of(Iterables.getLast(messages).offset());
+        needsCommitting = true;
+      }
+      return messages;
+    }
+  }
+
+  Optional<Long> position() {
+    try (CloseableMonitor.Hold h = monitor.enter()) {
+      return lastReceived.map(lastReceived -> lastReceived.value() + 1);
+    }
+  }
+
+  /** Executes a client-initiated commit. */
+  ApiFuture<Void> commitOffset(Offset offset) {
+    return committer.commitOffset(offset);
+  }
+
+  /** Auto-commits the offset of the last received message. */
+  Optional<ApiFuture<Offset>> autoCommit() {
+    try (CloseableMonitor.Hold h = monitor.enter()) {
+      if (!needsCommitting) return Optional.empty();
+      checkState(lastReceived.isPresent());
+      needsCommitting = false;
+      // The Pub/Sub Lite commit offset is one more than the last received.
+      Offset toCommit = Offset.of(lastReceived.get().value() + 1);
+      return Optional.of(
+          ApiFutures.transform(
+              committer.commitOffset(toCommit),
+              ignored -> toCommit,
+              MoreExecutors.directExecutor()));
+    }
+  }
+
+  void close() throws CheckedApiException {
+    try (CloseableMonitor.Hold h = monitor.enter()) {
+      subscriber.close();
+    }
+    committer.stopAsync().awaitTerminated();
+  }
+
+  private boolean onSubscriberReset() throws CheckedApiException {
+    // Handle an out-of-band seek notification from the server. There must be no pending commits
+    // after this function returns.
+    try (CloseableMonitor.Hold h = monitor.enter()) {
+      // Discard undelivered messages.
+      pullMessages();
+      // Prevent further auto-commits until post-seek messages are received.
+      needsCommitting = false;
+    }
+    committer.waitUntilEmpty();
+    return true;
+  }
+}

--- a/src/test/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriberTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriberTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.pubsublite.kafka;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsublite.Message;
+import com.google.cloud.pubsublite.Offset;
+import com.google.cloud.pubsublite.Partition;
+import com.google.cloud.pubsublite.SequencedMessage;
+import com.google.cloud.pubsublite.internal.BlockingPullSubscriber;
+import com.google.cloud.pubsublite.internal.CheckedApiException;
+import com.google.cloud.pubsublite.internal.wire.Committer;
+import com.google.cloud.pubsublite.internal.wire.SubscriberResetHandler;
+import com.google.cloud.pubsublite.proto.SeekRequest;
+import com.google.cloud.pubsublite.proto.SeekRequest.NamedTarget;
+import com.google.protobuf.Timestamp;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+@RunWith(JUnit4.class)
+public class SinglePartitionSubscriberTest {
+  private static final SeekRequest INITIAL_SEEK =
+      SeekRequest.newBuilder().setNamedTarget(NamedTarget.COMMITTED_CURSOR).build();
+  private static final Partition PARTITION = Partition.of(2);
+
+  @Mock PullSubscriberFactory subscriberFactory;
+  @Mock Committer committer;
+  @Mock BlockingPullSubscriber pullSubscriber;
+
+  @Captor private ArgumentCaptor<SubscriberResetHandler> resetHandlerCaptor;
+
+  private SinglePartitionSubscriber subscriber;
+
+  @Before
+  public void setUp() throws CheckedApiException {
+    initMocks(this);
+    when(subscriberFactory.newPullSubscriber(eq(PARTITION), eq(INITIAL_SEEK), any()))
+        .thenReturn(pullSubscriber);
+    subscriber =
+        new SinglePartitionSubscriber(subscriberFactory, PARTITION, INITIAL_SEEK, committer);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    verifyNoMoreInteractions(subscriberFactory);
+    verifyNoMoreInteractions(pullSubscriber);
+    verifyNoMoreInteractions(committer);
+  }
+
+  private static SequencedMessage message(long offset) {
+    return SequencedMessage.of(
+        Message.builder().build(), Timestamp.getDefaultInstance(), Offset.of(offset), 0L);
+  }
+
+  @Test
+  public void pullAndCommit() throws Exception {
+    verify(subscriberFactory).newPullSubscriber(eq(PARTITION), eq(INITIAL_SEEK), any());
+
+    when(pullSubscriber.messageIfAvailable())
+        .thenReturn(Optional.of(message(3)))
+        .thenReturn(Optional.of(message(5)))
+        .thenReturn(Optional.of(message(7)))
+        .thenReturn(Optional.empty());
+    assertThat(subscriber.getMessages()).containsExactly(message(3), message(5), message(7));
+    assertThat(subscriber.position()).hasValue(8);
+    verify(pullSubscriber, times(4)).messageIfAvailable();
+
+    when(committer.commitOffset(Offset.of(8))).thenReturn(ApiFutures.immediateFuture(null));
+    subscriber.autoCommit();
+    verify(committer).commitOffset(Offset.of(8));
+
+    // Second auto commit does nothing.
+    subscriber.autoCommit();
+  }
+
+  @Test
+  public void resetSubscriber() throws Exception {
+    verify(subscriberFactory)
+        .newPullSubscriber(eq(PARTITION), eq(INITIAL_SEEK), resetHandlerCaptor.capture());
+
+    when(pullSubscriber.messageIfAvailable())
+        .thenReturn(Optional.of(message(3)))
+        .thenReturn(Optional.of(message(5)))
+        .thenReturn(Optional.of(message(7)))
+        .thenReturn(Optional.empty());
+    assertThat(subscriber.getMessages()).containsExactly(message(3), message(5), message(7));
+
+    when(pullSubscriber.messageIfAvailable())
+        .thenReturn(Optional.of(message(9)))
+        .thenReturn(Optional.empty());
+    assertThat(resetHandlerCaptor.getValue().handleReset()).isTrue();
+    verify(committer).waitUntilEmpty();
+    verify(pullSubscriber, times(6)).messageIfAvailable();
+
+    // Subsequent messages are discarded.
+    assertThat(subscriber.position()).hasValue(8);
+
+    // Auto commit does nothing.
+    subscriber.autoCommit();
+  }
+}

--- a/src/test/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImplTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImplTest.java
@@ -93,8 +93,10 @@ public class SingleSubscriptionConsumerImplTest {
         new SingleSubscriptionConsumerImpl(
             example(TopicPath.class), false, subscriberFactory, committerFactory);
     verifyNoInteractions(subscriberFactory, committerFactory);
-    when(subscriberFactory.newPullSubscriber(eq(Partition.of(5)), any())).thenReturn(subscriber5);
-    when(subscriberFactory.newPullSubscriber(eq(Partition.of(8)), any())).thenReturn(subscriber8);
+    when(subscriberFactory.newPullSubscriber(eq(Partition.of(5)), any(), any()))
+        .thenReturn(subscriber5);
+    when(subscriberFactory.newPullSubscriber(eq(Partition.of(8)), any(), any()))
+        .thenReturn(subscriber8);
     when(committerFactory.newCommitter(Partition.of(5))).thenReturn(committer5);
     when(committerFactory.newCommitter(Partition.of(8))).thenReturn(committer8);
   }
@@ -120,8 +122,8 @@ public class SingleSubscriptionConsumerImplTest {
   @Test
   public void assignAndPoll() throws Exception {
     consumer.setAssignment(ImmutableSet.of(Partition.of(5), Partition.of(8)));
-    verify(subscriberFactory).newPullSubscriber(Partition.of(5), DEFAULT_SEEK);
-    verify(subscriberFactory).newPullSubscriber(Partition.of(8), DEFAULT_SEEK);
+    verify(subscriberFactory).newPullSubscriber(eq(Partition.of(5)), eq(DEFAULT_SEEK), any());
+    verify(subscriberFactory).newPullSubscriber(eq(Partition.of(8)), eq(DEFAULT_SEEK), any());
     verify(committerFactory).newCommitter(Partition.of(5));
     verify(committerFactory).newCommitter(Partition.of(8));
     // -----------------------------
@@ -202,8 +204,8 @@ public class SingleSubscriptionConsumerImplTest {
         new SingleSubscriptionConsumerImpl(
             example(TopicPath.class), true, subscriberFactory, committerFactory);
     consumer.setAssignment(ImmutableSet.of(Partition.of(5), Partition.of(8)));
-    verify(subscriberFactory).newPullSubscriber(Partition.of(5), DEFAULT_SEEK);
-    verify(subscriberFactory).newPullSubscriber(Partition.of(8), DEFAULT_SEEK);
+    verify(subscriberFactory).newPullSubscriber(eq(Partition.of(5)), eq(DEFAULT_SEEK), any());
+    verify(subscriberFactory).newPullSubscriber(eq(Partition.of(8)), eq(DEFAULT_SEEK), any());
     verify(committerFactory).newCommitter(Partition.of(5));
     verify(committerFactory).newCommitter(Partition.of(8));
     // -----------------------------
@@ -293,12 +295,12 @@ public class SingleSubscriptionConsumerImplTest {
   public void assignmentChange() throws Exception {
     consumer.setAssignment(ImmutableSet.of(Partition.of(5)));
     assertThat(consumer.assignment()).isEqualTo(ImmutableSet.of(Partition.of(5)));
-    verify(subscriberFactory).newPullSubscriber(Partition.of(5), DEFAULT_SEEK);
+    verify(subscriberFactory).newPullSubscriber(eq(Partition.of(5)), eq(DEFAULT_SEEK), any());
     verify(committerFactory).newCommitter(Partition.of(5));
     verify(committer5).startAsync();
     consumer.setAssignment(ImmutableSet.of(Partition.of(8)));
     assertThat(consumer.assignment()).isEqualTo(ImmutableSet.of(Partition.of(8)));
-    verify(subscriberFactory).newPullSubscriber(Partition.of(8), DEFAULT_SEEK);
+    verify(subscriberFactory).newPullSubscriber(eq(Partition.of(8)), eq(DEFAULT_SEEK), any());
     verify(committerFactory).newCommitter(Partition.of(8));
     verify(committer8).startAsync();
     verify(subscriber5).close();
@@ -309,7 +311,7 @@ public class SingleSubscriptionConsumerImplTest {
   public void assignmentChangeMakesPollReturn() throws Exception {
     consumer.setAssignment(ImmutableSet.of(Partition.of(5)));
     assertThat(consumer.assignment()).isEqualTo(ImmutableSet.of(Partition.of(5)));
-    verify(subscriberFactory).newPullSubscriber(Partition.of(5), DEFAULT_SEEK);
+    verify(subscriberFactory).newPullSubscriber(eq(Partition.of(5)), eq(DEFAULT_SEEK), any());
     when(subscriber5.onData()).thenReturn(SettableApiFuture.create());
     SettableApiFuture<Void> pollRunning = SettableApiFuture.create();
     when(subscriber5.onData())
@@ -358,12 +360,13 @@ public class SingleSubscriptionConsumerImplTest {
   @Test
   public void seekAssigned() throws Exception {
     consumer.setAssignment(ImmutableSet.of(Partition.of(5)));
-    verify(subscriberFactory).newPullSubscriber(Partition.of(5), DEFAULT_SEEK);
+    verify(subscriberFactory).newPullSubscriber(eq(Partition.of(5)), eq(DEFAULT_SEEK), any());
     verify(committerFactory).newCommitter(Partition.of(5));
-    when(subscriberFactory.newPullSubscriber(Partition.of(5), OFFSET_SEEK)).thenReturn(subscriber8);
+    when(subscriberFactory.newPullSubscriber(eq(Partition.of(5)), eq(OFFSET_SEEK), any()))
+        .thenReturn(subscriber8);
     consumer.doSeek(Partition.of(5), OFFSET_SEEK);
     verify(subscriber5).close();
-    verify(subscriberFactory).newPullSubscriber(Partition.of(5), OFFSET_SEEK);
+    verify(subscriberFactory).newPullSubscriber(eq(Partition.of(5)), eq(OFFSET_SEEK), any());
   }
 
   @Test

--- a/src/test/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImplTest.java
+++ b/src/test/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImplTest.java
@@ -193,9 +193,7 @@ public class SingleSubscriptionConsumerImplTest {
     verify(subscriber5).close();
     verify(subscriber8).close();
     verify(committer5).stopAsync();
-    verify(committer5).awaitTerminated();
     verify(committer8).stopAsync();
-    verify(committer8).awaitTerminated();
   }
 
   @Test
@@ -266,9 +264,7 @@ public class SingleSubscriptionConsumerImplTest {
     verify(subscriber5).close();
     verify(subscriber8).close();
     verify(committer5).stopAsync();
-    verify(committer5).awaitTerminated();
     verify(committer8).stopAsync();
-    verify(committer8).awaitTerminated();
   }
 
   @Test


### PR DESCRIPTION
Resets the Kafka Consumer state to handle admin seeks pushed from the server.

* `SubscriberState` was refactored out into `SinglePartitionSubscriber`. The main motivation was to give each subscriber state its own mutex and update its internal state (for auto-commits) atomically when pulling messages.
  * SingleSubscriptionConsumerImplTest was mostly left as-is to verify that this is a no-op.
* Added `SinglePartitionSubscriber::onSubscriberReset()` to reset subscriber state and wait for commits when the `RESET` signal is received from the server.
  * Undelivered messages are discarded. Further auto-commits are prevented until post-seek messages are received. 