### PR TITLE
chore: update repo metadata to use 'pubsublite' as "api_shortname"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,7 +21,7 @@ If you are still having issues, please include as much information as possible:
    General, Core, and Other are also allowed as types
 2. OS type and version:
 3. Java version:
-4.  version(s):
+4. pubsublite-kafka version(s):
 
 #### Steps to reproduce
 

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,6 +1,7 @@
 {
-  "api_shortname": "pubsublite-kafka",
+  "name": "pubsublite-kafka",
   "name_pretty": "Pub/Sub Lite Kafka Shim",
+  "api_shortname": "pubsublite",
   "product_documentation": "https://cloud.google.com/pubsub/lite/docs",
   "api_description": "Pub/Sub Lite is a zonal, real-time messaging service that lets you send and receive messages between independent applications. You can manually configure the throughput and storage capacity for Pub/Sub Lite systems.",
   "client_documentation": "https://cloud.google.com/java/docs/reference/pubsublite-kafka/latest/history",


### PR DESCRIPTION
The "api_shortname" field references the underlying service API, which in this case is Pub/Sub Lite. I added in "name" = "pubsublite-kafka" to clarify.

Fixes #274  ☕️
