### PR TITLE
feat: narrow credentials scope to pubsub

### DIFF
--- a/pubsublite-kafka-auth/src/main/java/com/google/cloud/pubsublite/kafka/internal/AuthServer.java
+++ b/pubsublite-kafka-auth/src/main/java/com/google/cloud/pubsublite/kafka/internal/AuthServer.java
@@ -93,7 +93,7 @@ public class AuthServer {
     try {
       GoogleCredentials creds =
           GoogleCredentials.getApplicationDefault()
-              .createScoped("https://www.googleapis.com/auth/cloud-platform");
+              .createScoped("https://www.googleapis.com/auth/pubsub");
       HttpServer server = HttpServer.create(ADDRESS, 0);
       server.createContext(
           "/",


### PR DESCRIPTION
We should scope to Pub/Sub instead of all of cloud.

https://developers.google.com/identity/protocols/oauth2/scopes#pubsub