### PR TITLE
fix: Update kafka-clients to 3.8.0 past snappy CVEs and implement dum…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
-        <version>3.4.0</version>
+        <version>3.8.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/PubsubLiteConsumer.java
+++ b/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/PubsubLiteConsumer.java
@@ -64,6 +64,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 
 /**
  * A class that uses a SingleSubscriptionConsumer to remove the duplicate methods from the kafka
@@ -119,6 +120,12 @@ class PubsubLiteConsumer implements Consumer<byte[], byte[]> {
       throw new IllegalStateException("Neither subscribe nor assign has been called.");
     }
     return consumer.get();
+  }
+
+  @Override
+  public Uuid clientInstanceId(Duration timeout) {
+    // https://javadoc.io/static/org.apache.kafka/kafka-clients/3.8.0/org/apache/kafka/clients/consumer/KafkaConsumer.html#clientInstanceId-java.time.Duration-
+    throw new IllegalStateException("Pub/Sub Lite Kafka Connector does not support telemetry");
   }
 
   @Override

--- a/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/PubsubLiteProducer.java
+++ b/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/PubsubLiteProducer.java
@@ -48,6 +48,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 
 class PubsubLiteProducer implements Producer<byte[], byte[]> {
@@ -75,6 +76,12 @@ class PubsubLiteProducer implements Producer<byte[], byte[]> {
         },
         MoreExecutors.directExecutor());
     this.publisher.startAsync().awaitRunning();
+  }
+
+  @Override
+  public Uuid clientInstanceId(Duration timeout) {
+    // https://javadoc.io/static/org.apache.kafka/kafka-clients/3.8.0/org/apache/kafka/clients/consumer/KafkaConsumer.html#clientInstanceId-java.time.Duration-
+    throw new IllegalStateException("Pub/Sub Lite Kafka Connector does not support telemetry");
   }
 
   @Override


### PR DESCRIPTION
…my `clientInstanceId`

Prior kafka-clients library version (3.4.0) depended on older versions of snappy https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients/3.4.0
