### PR TITLE
deps: Update google-cloud-pubsublite-parent version to 1.14.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pubsublite-parent</artifactId>
-    <version>1.12.1</version>
+    <version>1.14.5</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
@@ -17,22 +17,9 @@
     <module>pubsublite-kafka</module>
     <module>pubsublite-kafka-auth</module>
   </modules>
-  <properties>
-    <psl.version>1.12.1</psl.version>
-  </properties>
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.google.api.grpc</groupId>
-        <artifactId>proto-google-cloud-pubsublite-v1</artifactId>
-        <version>${psl.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>google-cloud-pubsublite</artifactId>
-        <version>${psl.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka-clients</artifactId>
@@ -40,4 +27,14 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.google.api.grpc</groupId>
+      <artifactId>proto-google-cloud-pubsublite-v1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-pubsublite</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/pubsublite-kafka-auth/pom.xml
+++ b/pubsublite-kafka-auth/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>pubsublite-kafka-parent</artifactId>
@@ -31,4 +33,18 @@
       <artifactId>guava</artifactId>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <dependency>com.google.flogger:google-extensions</dependency>
+            <dependency>com.google.api.grpc:proto-google-cloud-pubsublite-v1</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pubsublite-kafka/pom.xml
+++ b/pubsublite-kafka/pom.xml
@@ -54,10 +54,6 @@
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-    </dependency>
     <!--test dependencies-->
     <dependency>
       <groupId>junit</groupId>

--- a/pubsublite-kafka/pom.xml
+++ b/pubsublite-kafka/pom.xml
@@ -70,11 +70,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.google.truth.extensions</groupId>
-      <artifactId>truth-java8-extension</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriber.java
+++ b/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriber.java
@@ -31,7 +31,6 @@ import com.google.cloud.pubsublite.proto.SeekRequest;
 import com.google.cloud.pubsublite.proto.SequencedMessage;
 import com.google.common.collect.Iterables;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.ArrayDeque;
 import java.util.Optional;
 
@@ -44,13 +43,14 @@ class SinglePartitionSubscriber extends ProxyService {
 
   private final CloseableMonitor monitor = new CloseableMonitor();
 
-  @GuardedBy("monitor.monitor")
+  // New versions of ErrorProne do not recognize CloseableMonitor
+  // @GuardedBy("monitor.monitor")
   private BlockingPullSubscriber subscriber;
 
-  @GuardedBy("monitor.monitor")
+  // @GuardedBy("monitor.monitor")
   private boolean needsCommitting = false;
 
-  @GuardedBy("monitor.monitor")
+  // @GuardedBy("monitor.monitor")
   private Optional<Offset> lastReceived = Optional.empty();
 
   SinglePartitionSubscriber(
@@ -99,7 +99,7 @@ class SinglePartitionSubscriber extends ProxyService {
     }
   }
 
-  @GuardedBy("monitor.monitor")
+  // @GuardedBy("monitor.monitor")
   private ArrayDeque<SequencedMessage> pullMessages() throws CheckedApiException {
     ArrayDeque<SequencedMessage> messages = new ArrayDeque<>();
     for (Optional<SequencedMessage> message = subscriber.messageIfAvailable();

--- a/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriber.java
+++ b/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriber.java
@@ -43,14 +43,10 @@ class SinglePartitionSubscriber extends ProxyService {
 
   private final CloseableMonitor monitor = new CloseableMonitor();
 
-  // New versions of ErrorProne do not recognize CloseableMonitor
-  // @GuardedBy("monitor.monitor")
   private BlockingPullSubscriber subscriber;
 
-  // @GuardedBy("monitor.monitor")
   private boolean needsCommitting = false;
 
-  // @GuardedBy("monitor.monitor")
   private Optional<Offset> lastReceived = Optional.empty();
 
   SinglePartitionSubscriber(
@@ -99,7 +95,6 @@ class SinglePartitionSubscriber extends ProxyService {
     }
   }
 
-  // @GuardedBy("monitor.monitor")
   private ArrayDeque<SequencedMessage> pullMessages() throws CheckedApiException {
     ArrayDeque<SequencedMessage> messages = new ArrayDeque<>();
     for (Optional<SequencedMessage> message = subscriber.messageIfAvailable();

--- a/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImpl.java
+++ b/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImpl.java
@@ -67,11 +67,12 @@ class SingleSubscriptionConsumerImpl implements SingleSubscriptionConsumer {
 
   private final CloseableMonitor monitor = new CloseableMonitor();
 
-  @GuardedBy("monitor.monitor")
+  // New versions of ErrorProne do not recognize CloseableMonitor
+  // @GuardedBy("monitor.monitor")
   private final Map<Partition, SinglePartitionSubscriber> partitions = new HashMap<>();
   // When the set of assignments changes, this future will be set and swapped with a new future to
   // let ongoing pollers know that they should pick up new assignments.
-  @GuardedBy("monitor.monitor")
+  // @GuardedBy("monitor.monitor")
   private SettableApiFuture<Void> assignmentChanged = SettableApiFuture.create();
 
   // Set when wakeup() has been called once.

--- a/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImpl.java
+++ b/pubsublite-kafka/src/main/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImpl.java
@@ -37,7 +37,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.GoogleLogger;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
@@ -67,12 +66,9 @@ class SingleSubscriptionConsumerImpl implements SingleSubscriptionConsumer {
 
   private final CloseableMonitor monitor = new CloseableMonitor();
 
-  // New versions of ErrorProne do not recognize CloseableMonitor
-  // @GuardedBy("monitor.monitor")
   private final Map<Partition, SinglePartitionSubscriber> partitions = new HashMap<>();
   // When the set of assignments changes, this future will be set and swapped with a new future to
   // let ongoing pollers know that they should pick up new assignments.
-  // @GuardedBy("monitor.monitor")
   private SettableApiFuture<Void> assignmentChanged = SettableApiFuture.create();
 
   // Set when wakeup() has been called once.
@@ -90,7 +86,6 @@ class SingleSubscriptionConsumerImpl implements SingleSubscriptionConsumer {
   }
 
   @Override
-  @SuppressWarnings("GuardedBy")
   public void setAssignment(Set<Partition> assignment) {
     try (CloseableMonitor.Hold h = monitor.enter()) {
 
@@ -215,7 +210,6 @@ class SingleSubscriptionConsumerImpl implements SingleSubscriptionConsumer {
   }
 
   @Override
-  @SuppressWarnings("GuardedBy")
   public ApiFuture<Void> commit(Map<Partition, Offset> commitOffsets) {
     try (CloseableMonitor.Hold h = monitor.enter()) {
       ImmutableList.Builder<ApiFuture<?>> commitFutures = ImmutableList.builder();

--- a/pubsublite-kafka/src/test/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriberTest.java
+++ b/pubsublite-kafka/src/test/java/com/google/cloud/pubsublite/kafka/SinglePartitionSubscriberTest.java
@@ -17,7 +17,6 @@
 package com.google.cloud.pubsublite.kafka;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;

--- a/pubsublite-kafka/src/test/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImplTest.java
+++ b/pubsublite-kafka/src/test/java/com/google/cloud/pubsublite/kafka/SingleSubscriptionConsumerImplTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.pubsublite.kafka;
 
 import static com.google.cloud.pubsublite.internal.testing.UnitTestExamples.example;
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;

--- a/pubsublite-kafka/src/test/java/com/google/cloud/pubsublite/kafka/StatusTestHelpers.java
+++ b/pubsublite-kafka/src/test/java/com/google/cloud/pubsublite/kafka/StatusTestHelpers.java
@@ -17,7 +17,6 @@
 package com.google.cloud.pubsublite.kafka;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.google.api.gax.rpc.StatusCode.Code;


### PR DESCRIPTION
deps: Remove explicit version of pubsublite libraries. Depend on version inherited from parent
chore: disable GuardedBy where CloseableMonitor is used. Newer versions of ErrorProne do not recognize CloseableMonitor as satisfying GuardedBy