### PR TITLE
deps: Update gson to 2.13.1

### DIFF
--- a/pubsublite-kafka-auth/pom.xml
+++ b/pubsublite-kafka-auth/pom.xml
@@ -27,6 +27,13 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
+      <version>2.13.1</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Excluding `com.google.errorprone.error_prone_annotations` addresses an `org.apache.maven.enforcer.rules.dependency.RequireUpperBoundDeps` error.