### PR TITLE
deps: google-cloud-pubsublite-parent to the latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-pubsublite-parent</artifactId>
-    <version>1.14.6</version>
+    <version>1.15.9</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>

--- a/pubsublite-kafka/pom.xml
+++ b/pubsublite-kafka/pom.xml
@@ -54,6 +54,15 @@
       <groupId>com.google.auto.value</groupId>
       <artifactId>auto-value-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.flogger</groupId>
+      <artifactId>flogger</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax-grpc</artifactId>
+    </dependency>
+
     <!--test dependencies-->
     <dependency>
       <groupId>junit</groupId>

--- a/pubsublite-kafka/pom.xml
+++ b/pubsublite-kafka/pom.xml
@@ -57,6 +57,7 @@
     <dependency>
       <groupId>com.google.flogger</groupId>
       <artifactId>flogger</artifactId>
+      <version>0.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>


### PR DESCRIPTION
The latest google-cloud-pubsublite-parent has the profile to turn
off nexus-staging-maven-plugin. This profile is needed ot adopt
Central Portal migration.

The following command worked:

```
suztomo@suztomo2:~/java-pubsublite-kafka$ mvn clean deploy -V     -DaltDeploymentRepository=local::default::file:${local_staging_dir}     -DskipTests=true     -P=-release-sonatype     -P=-release-staging-repository     -P=-clirr-compatibility-check     -P=-checkstyle-tests     -P=-animal-sniffer

Uploaded to local: file:./target/staging-deploy/com/google/cloud/pubsublite-kafka-auth/1.2.3/pubsublite-kafka-auth-1.2.3.jar (10 kB at 5.0 MB/s)
Downloading from local: file:./target/staging-deploy/com/google/cloud/pubsublite-kafka-auth/maven-metadata.xml
Uploading to local: file:./target/staging-deploy/com/google/cloud/pubsublite-kafka-auth/maven-metadata.xml
Uploaded to local: file:./target/staging-deploy/com/google/cloud/pubsublite-kafka-auth/maven-metadata.xml (317 B at 317 kB/s)
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Pub/Sub Lite Kafka Parent 1.2.3:
[INFO] 
[INFO] Pub/Sub Lite Kafka Parent .......................... SUCCESS [  2.263 s]
[INFO] Pub/Sub Lite Kafka Shim ............................ SUCCESS [ 13.292 s]
[INFO] Pub/Sub Lite Kafka Auth ............................ SUCCESS [  3.523 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  19.699 s
[INFO] Finished at: 2025-06-17T16:10:42-04:00
[INFO] ------------------------------------------------------------------------

```