### PR TITLE
chore: replace old partner teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,11 +4,11 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-# The @googleapis/api-pubsublite is the default owner for changes in this repo
-*                       @googleapis/cloud-sdk-java-team @googleapis/api-pubsublite
+# The @googleapis/managed-kafka-team is the default owner for changes in this repo
+*                       @googleapis/cloud-sdk-java-team @googleapis/managed-kafka-team
 
 # for handwritten libraries, keep codeowner_team in .repo-metadata.json as owner
-**/*.java               @googleapis/api-pubsublite
+**/*.java               @googleapis/managed-kafka-team
 
 
 # The java-samples-reviewers team is the default owner for samples changes

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -36,7 +36,7 @@ permissionRules:
     permission: admin
   - team: yoshi-java-admins
     permission: admin
-  - team: yoshi-java
+  - team: cloud-sdk-java-team
     permission: push
-  - team: api-pubsublite
+  - team: managed-kafka-team
     permission: admin

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -13,7 +13,7 @@
   "repo": "googleapis/java-pubsublite-kafka",
   "repo_short": "java-pubsublite-kafka",
   "distribution_name": "com.google.cloud:pubsublite-kafka",
-  "codeowner_team": "@googleapis/api-pubsublite",
+  "codeowner_team": "@googleapis/managed-kafka-team",
   "library_type": "AGENT",
   "api_id": "pubsublite.googleapis.com"
 }


### PR DESCRIPTION
This PR replaces @googleapis/api-pubsublite with @googleapis/managed-kafka-team and @googleapis/yoshi-java with @googleapis/cloud-sdk-java-team. b/478003109